### PR TITLE
Add .qodo to .gitignore to exclude Qodo configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,4 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+.qodo


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added `.qodo` to `.gitignore` to exclude Qodo configuration files.

- Ensures the repository is ready for use with Qodo by ignoring its specific configuration files.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>